### PR TITLE
Footer: Updated contact and privacy notice link from uie.com to centercentre.com. Removed 800 number.

### DIFF
--- a/index.html
+++ b/index.html
@@ -824,7 +824,7 @@
                     </div>
                     <div class="b2">
                         <p>
-                            791 Turnpike Street, Unit 4<br> North Andover, MA 01845<br> (800) 588-9855 or +1
+                            791 Turnpike Street, Unit 4<br> North Andover, MA 01845<br>+1
                             978-327-5561
                         </p>
                     </div>
@@ -842,9 +842,9 @@
                     </span>
                     <span>
                         Questions or comments?
-                        <a href="https://www.uie.com/contact">Contact us. </a>
+                        <a href="https://www.centercentre.com/contact">Contact us. </a>
                     </span>
-                    <span><a href="https://www.uie.com/privacy-notice/">Privacy Notice</a></span>
+                    <span><a href="https://www.centercentre.com/privacy-notice/">Privacy Notice</a></span>
                 </div>
 
 


### PR DESCRIPTION
Footer needed to be updated to reflect centercentre.com as the main site and remove an out of date contact number.